### PR TITLE
Simplify label display and using temporary file name

### DIFF
--- a/disk-speed-test.sh
+++ b/disk-speed-test.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-echo -e "\n\n"
-seq  -f "#" -s '' 30; echo -e "\n"
-echo -e "macOS Disk Speed Test\n"
-seq  -f "#" -s '' 30
-echo -e "\n\n"
+cat <<EOT
+
+##############################
+macOS Disk Speed Test
+##############################
+
+EOT
 
 echo -n "Write Speed: "
 dd if=/dev/zero bs=2048k of=tstfile count=1024 2>&1 | awk  -F'[^0-9]*' 'END{print $4 / 1048576 ,"MB/sec"}'

--- a/disk-speed-test.sh
+++ b/disk-speed-test.sh
@@ -8,10 +8,11 @@ macOS Disk Speed Test
 
 EOT
 
+tstfile=`mktemp`
 echo -n "Write Speed: "
-dd if=/dev/zero bs=2048k of=tstfile count=1024 2>&1 | awk  -F'[^0-9]*' 'END{print $4 / 1048576 ,"MB/sec"}'
+dd if=/dev/zero bs=2048k of=$tstfile count=1024 2>&1 | awk  -F'[^0-9]*' 'END{print $4 / 1048576 ,"MB/sec"}'
 
 echo -n "Read Speed: "
-dd if=tstfile bs=2048k of=/dev/null count=1024 2>&1 | awk  -F'[^0-9]*' 'END{print $4 / 1048576 ,"MB/sec"}'
+dd if=$tstfile bs=2048k of=/dev/null count=1024 2>&1 | awk  -F'[^0-9]*' 'END{print $4 / 1048576 ,"MB/sec"}'
 
-rm -rf tstfile
+rm -rf $tstfile


### PR DESCRIPTION
A hem, :)
This change should make the program less complicate by not depend on 'seq' command to display part of label of the program. Also I found that 'seq' on macos seems not compatible with one on linux.
Using temporary file name should be a better choice than specific file name for create temporary file.